### PR TITLE
Use docker to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# xorm tests
+
 Xorm is a simple and powerful ORM for Go.
 
 [![Build Status](https://drone.io/github.com/go-xorm/tests/status.png)](https://drone.io/github.com/go-xorm/tests/latest)  [![Go Walker](http://gowalker.org/api/v1/badge)](http://gowalker.org/github.com/go-xorm/xorm) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/lunny/xorm/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
@@ -6,26 +8,63 @@ This is the tests project for xorm.
 
 Please add your test codes here if you want to pull request to xorm.
 
-# How to run the tests
+### How to run the tests
 
 * test sqlite
 
-```
-./sqlite3.sh
-```
+ ```
+ ./sqlite3.sh
+ ```
 
-* test mysql
+* test mysql or mymysql
 
-Create empty database xorm_test, xorm_test1, xorm_test3 on your mysql server and make an account root, and let passwd is empty on localhost, and then
+ Create empty databases `xorm_test`, `xorm_test1`, `xorm_test2`, `xorm_test3` on your mysql server and make an account root, and let passwd empty on localhost, and then run:
 
-```
-./mysql.sh
-```
+ ```
+ ./mysql.sh
+ ./mymysql.sh
+ ```
 
 * test postgres
 
-Create empty database xorm_test, xorm_test1, xorm_test3 on your postgres and make an account root, and let passwd is empty on localhost, and then
+ Create empty database `xorm_test` on your postgres and and let passwd empty for default account on localhost, and then run:
+
+ ```
+ ./postgres.sh
+ ```
+
+### Running tests by name
+
+You can also use `run_tests.sh` script:
 
 ```
-./postgres.sh
+./run_tests.sh <db>  # e.g. mysql
+```
+
+Run all tests:
+
+```
+./run_tests.sh
+```
+
+### Running tests using docker
+
+You can also use `run_tests_docker.sh` script that will pull and run preconfigured images with database engines, and run tests on them. With this approach, you don't need to configure anything, just install docker and run the script.
+
+Run specific test:
+
+```
+./run_tests_docker.sh <db>  # e.g. mysql
+```
+
+Run specific test with given database version:
+
+```
+./run_tests_docker.sh <db>:<version>  # e.g. mysql:5.5
+```
+
+Run all tests:
+
+```
+./run_tests_docker.sh
 ```

--- a/cmdline.go
+++ b/cmdline.go
@@ -1,0 +1,12 @@
+package tests
+
+import (
+	"flag"
+)
+
+var ConnectionPort string
+
+func init() {
+	flag.StringVar(&ConnectionPort, "port", "", "")
+	flag.Parse()
+}

--- a/mssql/mssql.sh
+++ b/mssql/mssql.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestMssql
+go test -v -run=TestMssql "$@"

--- a/mymysql/mymysql.sh
+++ b/mymysql/mymysql.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestMyMysql
+go test -v -run=TestMyMysql "$@"

--- a/mymysql/mymysql_test.go
+++ b/mymysql/mymysql_test.go
@@ -9,6 +9,14 @@ import (
 	_ "github.com/ziutek/mymysql/godrv"
 )
 
+func connStr(db string) string {
+	conn := ""
+	if ConnectionPort != "" {
+		conn = "tcp:127.0.0.1:" + ConnectionPort + "*"
+	}
+	return conn + db + "/root/"
+}
+
 /*
 CREATE DATABASE IF NOT EXISTS xorm_test CHARACTER SET
 utf8 COLLATE utf8_general_ci;
@@ -20,7 +28,7 @@ func TestMyMysql(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	engine, err := xorm.NewEngine("mymysql", "xorm_test/root/")
+	engine, err := xorm.NewEngine("mymysql", connStr("xorm_test"))
 	defer engine.Close()
 	if err != nil {
 		t.Error(err)
@@ -39,7 +47,7 @@ func TestMyMysqlWithCache(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	engine, err := xorm.NewEngine("mymysql", "xorm_test2/root/")
+	engine, err := xorm.NewEngine("mymysql", connStr("xorm_test2"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -54,7 +62,7 @@ func TestMyMysqlWithCache(t *testing.T) {
 }
 
 func newMyMysqlEngine() (*xorm.Engine, error) {
-	engine, err := xorm.NewEngine("mymysql", "xorm_test2/root/")
+	engine, err := xorm.NewEngine("mymysql", connStr("xorm_test2"))
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +71,7 @@ func newMyMysqlEngine() (*xorm.Engine, error) {
 }
 
 func newMyMysqlDriverDB() (*sql.DB, error) {
-	return sql.Open("mymysql", "xorm_test2/root/")
+	return sql.Open("mymysql", connStr("xorm_test2"))
 }
 
 func BenchmarkMyMysqlDriverInsert(t *testing.B) {
@@ -77,7 +85,7 @@ func BenchmarkMyMysqlDriverFind(t *testing.B) {
 }
 
 func mymysqlDdlImport() error {
-	engine, err := xorm.NewEngine("mymysql", "/root/")
+	engine, err := xorm.NewEngine("mymysql", connStr(""))
 	if err != nil {
 		return err
 	}
@@ -89,7 +97,7 @@ func mymysqlDdlImport() error {
 	if err != nil {
 		return err
 	}
-	engine.LogDebug("sql results: %v", sqlResults)
+	engine.Logger().Debug("sql results: %v", sqlResults)
 	return nil
 }
 

--- a/mysql/mysql.sh
+++ b/mysql/mysql.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestMysql
+go test -v -run=TestMysql "$@"

--- a/mysql/mysql_test.go
+++ b/mysql/mysql_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/go-xorm/xorm"
 )
 
+func connStr(db string) string {
+	conn := "root:@"
+	if ConnectionPort != "" {
+		conn += "tcp(127.0.0.1:" + ConnectionPort + ")"
+	}
+	return conn + "/" + db + "?charset=utf8"
+}
+
 /*
 CREATE DATABASE IF NOT EXISTS xorm_test CHARACTER SET
 utf8 COLLATE utf8_general_ci;
@@ -21,7 +29,7 @@ func TestMysql(t *testing.T) {
 		return
 	}
 
-	engine, err := xorm.NewEngine("mysql", "root:@/xorm_test?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr("xorm_test"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -43,7 +51,7 @@ func TestMysqlSameMapper(t *testing.T) {
 		return
 	}
 
-	engine, err := xorm.NewEngine("mysql", "root:@/xorm_test1?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr("xorm_test1"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -66,7 +74,7 @@ func TestMysqlGonicMapper(t *testing.T) {
 		return
 	}
 
-	engine, err := xorm.NewEngine("mysql", "root:@/xorm_test1?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr("xorm_test1"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -89,7 +97,7 @@ func TestMysqlWithCache(t *testing.T) {
 		return
 	}
 
-	engine, err := xorm.NewEngine("mysql", "root:@/xorm_test2?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr("xorm_test2"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -111,7 +119,7 @@ func TestMysqlWithCacheSameMapper(t *testing.T) {
 		return
 	}
 
-	engine, err := xorm.NewEngine("mysql", "root:@/xorm_test3?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr("xorm_test3"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -128,11 +136,11 @@ func TestMysqlWithCacheSameMapper(t *testing.T) {
 }
 
 func newMysqlEngine() (*xorm.Engine, error) {
-	return xorm.NewEngine("mysql", "root:@/xorm_test?charset=utf8")
+	return xorm.NewEngine("mysql", connStr("xorm_test"))
 }
 
 func mysqlDdlImport() error {
-	engine, err := xorm.NewEngine("mysql", "root:@/?charset=utf8")
+	engine, err := xorm.NewEngine("mysql", connStr(""))
 	if err != nil {
 		return err
 	}
@@ -148,7 +156,7 @@ func mysqlDdlImport() error {
 }
 
 func newMysqlDriverDB() (*sql.DB, error) {
-	return sql.Open("mysql", "root:@/xorm_test?charset=utf8")
+	return sql.Open("mysql", connStr("xorm_test"))
 }
 
 func BenchmarkMysqlDriverInsert(t *testing.B) {

--- a/oci8/oci8.sh
+++ b/oci8/oci8.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestOci8
+go test -v -run=TestOci8 "$@"

--- a/postgres/postgres.sh
+++ b/postgres/postgres.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestPostgres
+go test -v -run=TestPostgres "$@"

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -13,7 +13,7 @@ import (
 //var connStr string = "dbname=xorm_test user=lunny password=1234 sslmode=disable"
 
 func connStr() string {
-	conn := "postgres://?dbname=xorm_test&sslmode=disable"
+	conn := "postgres://?dbname=xorm_test&sslmode=disable&user=postgres"
 	if ConnectionPort != "" {
 		conn += "&port=" + ConnectionPort
 	}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -12,10 +12,16 @@ import (
 
 //var connStr string = "dbname=xorm_test user=lunny password=1234 sslmode=disable"
 
-var connStr string = "postgres://?dbname=xorm_test&sslmode=disable"
+func connStr() string {
+	conn := "postgres://?dbname=xorm_test&sslmode=disable"
+	if ConnectionPort != "" {
+		conn += "&port=" + ConnectionPort
+	}
+	return conn
+}
 
 func newPostgresEngine() (*xorm.Engine, error) {
-	orm, err := xorm.NewEngine("postgres", connStr)
+	orm, err := xorm.NewEngine("postgres", connStr())
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +42,7 @@ func newPostgresEngine() (*xorm.Engine, error) {
 }
 
 func newPostgresDriverDB() (*sql.DB, error) {
-	return sql.Open("postgres", connStr)
+	return sql.Open("postgres", connStr())
 }
 
 func TestPostgres(t *testing.T) {

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+if [ "$#" == "0" ];then
+    tests=('sqlite3' 'mysql' 'mymysql' 'postgres')
+else
+    tests=($@)
+fi
+
+mysqlcmd='for db in xorm_test xorm_test1 xorm_test2 xorm_test3
+do
+    mysql -h"$MYSQL_PORT_3306_TCP_ADDR" \
+          -P"$MYSQL_PORT_3306_TCP_PORT" \
+          -uroot --password="" \
+          --execute="CREATE DATABASE IF NOT EXISTS $db DEFAULT CHARACTER SET utf8;"
+done'
+
+postgrescmd='for db in xorm_test
+do
+    psql -h "$POSTGRES_PORT_5432_TCP_ADDR" \
+         -p "$POSTGRES_PORT_5432_TCP_PORT" \
+         -U postgres \
+         -c "DROP DATABASE IF EXISTS $db;"
+    psql -h "$POSTGRES_PORT_5432_TCP_ADDR" \
+         -p "$POSTGRES_PORT_5432_TCP_PORT" \
+         -U postgres \
+         -c "CREATE DATABASE $db;"
+done'
+
+parsename() {
+    echo "$1" | sed -re 's/:.*$//'
+}
+
+parsever() {
+    ver="$(echo "$1" | sed -re 's/^[^:]+(:([0-9]+[.][0-9]+))?$/\2/')"
+    echo "${ver:=$2}"
+}
+
+getport() {
+    num="$(echo "$2" | sed -re 's:[^0-9]::g')"
+    expr "10000" "+" "$1" "+" "${num:=0}"
+}
+
+runtest() {
+    t="$(parsename $1)"
+    p="$2"
+    ( cd $t && ./${t}.sh -timeout 20m -args -port $p )
+}
+
+for tst in "${tests[@]}"
+do
+    echo "* executing tests for $tst"
+    case $tst in
+        sqlite3)
+            echo "* getting dependencies"
+            go get -v github.com/mattn/go-sqlite3 || exit 1
+
+            echo "* running tests"
+            ./sqlite3.sh || exit 1
+            ;;
+
+        mysql*|mymysql*)
+            version=$(parsever $tst "5.5")
+            image="mysql:${version}"
+            name="xorm_mysql_${version}"
+            port="$(getport 1000 ${version})"
+
+            if ! docker ps -a | grep -q "$name"
+            then
+                echo "* starting container $name"
+                docker run --name $name \
+                       -e MYSQL_ROOT_PASSWORD="" \
+                       -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+                       -d \
+                       -p $port:3306 \
+                       $image \
+                    || exit 1
+            fi
+
+            echo "* polling server"
+            while :
+            do
+                echo -n "."
+                docker run --link $name:mysql --rm mysql \
+                       bash -c "$mysqlcmd" &>/dev/null \
+                    && break
+                sleep 1
+            done
+            echo
+            echo "* created tables"
+
+            echo "* getting dependencies"
+            case $tst in
+                mysql*)
+                    go get -v github.com/go-sql-driver/mysql || exit 1
+                    ;;
+                mymysql*)
+                    go get -v github.com/ziutek/mymysql/godrv || exit 1
+                    ;;
+            esac
+
+            echo "* running tests"
+            runtest $tst $port || exit 1
+            ;;
+
+        postgres)
+            version=$(parsever $tst "latest")
+            image="postgres:${version}"
+            name="xorm_postgres_${version}"
+            port="$(getport 2000 ${version})"
+
+            if ! docker ps -a | grep -q "$name"
+            then
+                echo "* starting container $name"
+                docker run --name $name \
+                       -e POSTGRES_PASSWORD="" \
+                       -d \
+                       -p $port:5432 \
+                       $image \
+                    || exit 1
+            fi
+
+            echo "* polling server"
+            while :
+            do
+                echo -n "."
+                docker run --link $name:postgres --rm postgres \
+                       bash -c "$postgrescmd" &>/dev/null \
+                    && break
+                sleep 1
+            done
+            echo
+            echo "* created tables"
+
+            echo "* getting dependencies"
+            go get -v github.com/lib/pq || exit 1
+
+            echo "* running tests"
+            runtest $tst $port || exit 1
+            ;;
+
+        *)
+            echo "unknown test type $t" 1>&2
+            exit 1
+    esac
+done

--- a/sqlite3/sqlite3.sh
+++ b/sqlite3/sqlite3.sh
@@ -1,1 +1,1 @@
-go test -v -run=TestSqlite3
+go test -v -run=TestSqlite3 "$@"


### PR DESCRIPTION
Hi. This PR adds `run_tests_docker.sh` script and updates README.

The script downloads and runs database engines (official images of mysql and postgres) using docker.

Thus, with this script you don't need to install and configure anything on your computer, you can just run the script. It's now possible to test various versions of databases as well.